### PR TITLE
Included package data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     },
     setup_requires=["setuptools_scm"],
     install_requires=required,
-    include_package_data=True
+    include_package_data=True,
     package_data={"databricks": ["pixels/resources/*"]},
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     },
     setup_requires=["setuptools_scm"],
     install_requires=required,
+    include_package_data=True
     package_data={"databricks": ["pixels/resources/*"]},
     extras_require={
         "dev": [


### PR DESCRIPTION
Latest versions of setup_tools requires include_package_data=True to add resources.
More info available [setuptools.pypa.io](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#include-package-data).
