### PR TITLE
initial implementation for pixels with streaming

### DIFF
--- a/tests/dbx/test_stream.py
+++ b/tests/dbx/test_stream.py
@@ -1,0 +1,52 @@
+import pytest
+from databricks.connect import DatabricksSession
+from databricks.sdk.core import DatabricksError
+from pyspark.sql import SparkSession
+from dbx.pixels import Catalog
+
+from dbx.pixels.dicom import DicomMetaExtractor, DicomThumbnailExtractor
+
+from databricks.sdk.runtime import dbutils
+
+from dbx.pixels.version import __version__
+
+FILE_PATH = "s3://hls-eng-data-public/dicom/ddsm/benigns/patient0007/"
+TABLE = "main.pixels_solacc.object_catalog_stream"
+CHECKPOINT_BASE_PATH = "/tmp/pixels_acc_stream_test/checkpoints/"
+
+@pytest.fixture()
+def spark() -> SparkSession:
+    """
+    Create a SparkSession (the entry point to Spark functionality) on
+    the cluster in the remote Databricks workspace. Unit tests do not
+    have access to this SparkSession by default.
+    """
+    return DatabricksSession.builder.getOrCreate()
+
+@pytest.fixture(autouse=True)
+def setup(spark: SparkSession):
+    spark.sql("CREATE DATABASE IF NOT EXISTS main.pixels_solacc")
+    yield
+    
+    try:
+        checkpoints = list(dbutils.fs.ls(CHECKPOINT_BASE_PATH))
+        if len(checkpoints) > 0:
+            dbutils.fs.rm(CHECKPOINT_BASE_PATH, True)
+    except DatabricksError as err:
+        if "No file or directory exists on path" in str(err):
+            print("Checkpoints folder clean, nothing to do")
+        else:
+            print(err)
+
+    spark.sql(f"DROP TABLE IF EXISTS {TABLE}")
+
+
+def test_catalog_stream(spark: SparkSession):
+    catalog = Catalog(spark, table=TABLE)
+    catalog_df = catalog.catalog(path=FILE_PATH, streaming=True, streamCheckpointBasePath=CHECKPOINT_BASE_PATH)
+
+    assert catalog_df is not None
+    
+    catalog.save(df=catalog_df)
+
+    assert catalog.load().count() == 4

--- a/tests/dbx/test_stream.py
+++ b/tests/dbx/test_stream.py
@@ -1,18 +1,15 @@
 import pytest
 from databricks.connect import DatabricksSession
 from databricks.sdk.core import DatabricksError
-from pyspark.sql import SparkSession
-from dbx.pixels import Catalog
-
-from dbx.pixels.dicom import DicomMetaExtractor, DicomThumbnailExtractor
-
 from databricks.sdk.runtime import dbutils
+from pyspark.sql import SparkSession
 
-from dbx.pixels.version import __version__
+from dbx.pixels import Catalog
 
 FILE_PATH = "s3://hls-eng-data-public/dicom/ddsm/benigns/patient0007/"
 TABLE = "main.pixels_solacc.object_catalog_stream"
 CHECKPOINT_BASE_PATH = "/tmp/pixels_acc_stream_test/checkpoints/"
+
 
 @pytest.fixture()
 def spark() -> SparkSession:
@@ -23,11 +20,12 @@ def spark() -> SparkSession:
     """
     return DatabricksSession.builder.getOrCreate()
 
+
 @pytest.fixture(autouse=True)
 def setup(spark: SparkSession):
     spark.sql("CREATE DATABASE IF NOT EXISTS main.pixels_solacc")
     yield
-    
+
     try:
         checkpoints = list(dbutils.fs.ls(CHECKPOINT_BASE_PATH))
         if len(checkpoints) > 0:
@@ -43,10 +41,12 @@ def setup(spark: SparkSession):
 
 def test_catalog_stream(spark: SparkSession):
     catalog = Catalog(spark, table=TABLE)
-    catalog_df = catalog.catalog(path=FILE_PATH, streaming=True, streamCheckpointBasePath=CHECKPOINT_BASE_PATH)
+    catalog_df = catalog.catalog(
+        path=FILE_PATH, streaming=True, streamCheckpointBasePath=CHECKPOINT_BASE_PATH
+    )
 
     assert catalog_df is not None
-    
+
     catalog.save(df=catalog_df)
 
     assert catalog.load().count() == 4


### PR DESCRIPTION
To enable the streaming capability a parameter is required in catalog reading step.

```python
from dbx.pixels import Catalog

catalog = Catalog(spark, table)
catalog_df = catalog.catalog(path, streaming=True)
```