### PR TITLE
Add handling for dicom files without pixel data

### DIFF
--- a/dbx/pixels/dicom/dicom_udfs.py
+++ b/dbx/pixels/dicom/dicom_udfs.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 
 from pyspark.sql.functions import udf
-
+from pydicom import Dataset
 
 def cloud_open(path: str, anon: bool = False):
     try:
@@ -19,6 +19,18 @@ def cloud_open(path: str, anon: bool = False):
     except Exception as e:
         raise Exception(f"path: {path} is_anon: {anon} exception: {e} exception.args: {e.args}")
 
+def check_pixel_data(ds: Dataset) -> Dataset | None:
+    """Check if pixel data exists before attempting to access it.
+        pydicom.Dataset.pixel_array will throw an exception if the
+        image contains no pixel data.
+    params:
+        df -- An object of type pydicom.Dataset
+    """
+    try:
+        a = ds.pixel_array
+    except:
+        return None
+    return a
 
 @udf
 def dicom_meta_udf(path: str, deep: bool = True, anon: bool = False) -> dict:
@@ -35,22 +47,27 @@ def dicom_meta_udf(path: str, deep: bool = True, anon: bool = False) -> dict:
 
         fp = cloud_open(path, anon)
         with dcmread(fp, defer_size=1000, stop_before_pixels=(not deep)) as ds:
+            a = None
             js = ds.to_json_dict()
             # remove binary images
             if "60003000" in js:
                 del js["60003000"]
             if "7FE00010" in js:
                 del js["7FE00010"]
-
             if deep:
+                a = check_pixel_data(ds)
+            if deep and a is not None:
                 a = ds.pixel_array
                 a.flags.writeable = False
+                js["has_pixel"] = True
                 js["hash"] = hashlib.sha1(a).hexdigest()
                 js["img_min"] = np.min(a).item()
                 js["img_max"] = np.max(a).item()
                 js["img_avg"] = np.average(a).item()
                 js["img_shape_x"] = a.shape[0]
                 js["img_shape_y"] = a.shape[1]
+            elif deep:
+                js["has_pixel"] = False
 
             return json.dumps(js)
     except Exception as err:


### PR DESCRIPTION
-Previously, dicom_meta_udf would return a json string in the form of an error message if no pixel data was found in the DICOM file.
-With this change, we return all of the metadata of the DICOM file, along with an extra key "has_pixel" indicating whether or not pydicom located pixel data in the file.