### PR TITLE
Inject MONAI Serving Endpoint proxy url in the cookie at startup

### DIFF
--- a/dbx/pixels/resources/lakehouse_app/app.py
+++ b/dbx/pixels/resources/lakehouse_app/app.py
@@ -50,6 +50,7 @@ with open(f"{ohif_path}/{file}.js", "r") as config_input:
         config_custom.write(
             config_input.read().replace("{ROUTER_BASENAME}", "").replace("{PIXELS_TABLE}", table)
         )
+        config_custom.write('document.cookie = "MONAILABEL_SERVER_URL="+window.location.origin+"/monai/; Path=/; Expires=Session;"')
 
 app = FastAPI(title="Pixels")
 


### PR DESCRIPTION
This pull request includes a small change to the `lakehouse_app/app.py` file. The change adds a line to set a cookie for the `MONAILABEL_SERVER_URL` with the current window location origin. 

Change in `lakehouse_app/app.py`:

* Added a line to write a cookie setting for `MONAILABEL_SERVER_URL` in the `config_custom` write operation.