### PR TITLE
PyTests Teardown Fix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -58,16 +58,10 @@ def setup_teardown_database(spark: SparkSession):
     
     yield
 
-    print("DROPPING TABLES, VOLUME AND SCHEMA")
-
-    # Drop all related tables
-    spark.sql(f"DROP TABLE IF EXISTS {TABLE}")
-    spark.sql(f"DROP TABLE IF EXISTS {TABLE}_unzip")
-    spark.sql(f"DROP TABLE IF EXISTS {TABLE}_autoseg_result")
+    print("DROPPING SCHEMA AND EVERYTHING IN IT")
     
-    # Drop volume and database
-    spark.sql(f"DROP VOLUME IF EXISTS {VOLUME_UC}")
-    spark.sql(f"DROP DATABASE IF EXISTS {CATALOG}.{SCHEMA}")
+    # Drop database
+    spark.sql(f"DROP DATABASE IF EXISTS {CATALOG}.{SCHEMA} CASCADE")
 
 @pytest.fixture(autouse=True)
 def cleanup_after_test(spark: SparkSession):


### PR DESCRIPTION
This pull request simplifies the teardown process in the `setup_teardown_database` function by consolidating the cleanup logic to drop the entire schema and its contents in one step.

Database cleanup simplification:

* [`conftest.py`](diffhunk://#diff-a31c7ed5d35f5ed8233994868c54d625b18e6bacb6794344c4531e62bd9dde59L61-R64): Updated the `setup_teardown_database` function to drop the entire schema and everything within it using the `CASCADE` option, replacing the previous logic that individually dropped tables, volumes, and the database.