### PR TITLE
Serverless Indexing perf and stability improvements

### DIFF
--- a/dbx/pixels/dicom/dicom_meta_extractor.py
+++ b/dbx/pixels/dicom/dicom_meta_extractor.py
@@ -65,7 +65,8 @@ class DicomMetaExtractor(Transformer):
                 fp, fsize = cloud_open(path, anon)
                 with dcmread(fp, defer_size=1000, stop_before_pixels=(not deep)) as dataset:
                     meta_js = extract_metadata(dataset, deep)
-                    meta_js["hash"] = hashlib.sha1(fp.read()).hexdigest()
+                    if deep:
+                        meta_js["hash"] = hashlib.sha1(fp.read()).hexdigest()
                     meta_js["file_size"] = fsize
                     return json.dumps(meta_js)
             except Exception as err:

--- a/dbx/pixels/dicom/dicom_utils.py
+++ b/dbx/pixels/dicom/dicom_utils.py
@@ -54,13 +54,15 @@ def extract_metadata(ds: Dataset, deep: bool = True) -> dict:
     """
     a = None
     js = ds.to_json_dict()
-    # remove binary images
-    if "60003000" in js:
-        del js["60003000"]
-    if "7FE00010" in js:
-        del js["7FE00010"]
+
     if deep:
+        # remove binary images
+        if "60003000" in js:
+            del js["60003000"]
+        if "7FE00010" in js:
+            del js["7FE00010"]
         a = check_pixel_data(ds)
+    
     if deep and a is not None:
         a.flags.writeable = False
         js["has_pixel"] = True

--- a/notebooks/transcoding/config.yaml
+++ b/notebooks/transcoding/config.yaml
@@ -1,0 +1,6 @@
+# for compression tests
+input_path: /Volumes/hls_radiology/demo/random/20250227134948_CT_ISRA_0.dcm
+output_path: /Volumes/hls_radiology/demo/random/20250227134948_CT_ISRA_0_{compression}.dcm
+table: hls_radiology.alpha.object_catalog
+volume: hls_radiology.alpha.pixels_volume
+write_mode: append

--- a/notebooks/transcoding/jpeg2000 v3 - index.ipynb
+++ b/notebooks/transcoding/jpeg2000 v3 - index.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "4d857a8b-5fd5-4068-90e3-78d1bd267e95",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Overview\n",
+    "Index the compressed file with Pixels in prep for display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "71381f8c-88cc-4948-89c3-027344f6f4b4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import dbx\n",
+    "\n",
+    "repo_main_folder = os.path.abspath(os.path.join(os.path.dirname(dbx.__file__), os.pardir))\n",
+    "print(f\"Installing Pixels Solution Accelerator dependencies from  {repo_main_folder}/requirements.txt\")\n",
+    "\n",
+    "%pip install --quiet -r {repo_main_folder}/requirements.txt\n",
+    "\n",
+    "dbutils.library.restartPython()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "fba52ea2-f8e5-47f0-b0cf-dfa01d480602",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "import pprint\n",
+    "compression = \"nvImage_HTJ2K\"\n",
+    "cfg = yaml.safe_load(open(\"config.yaml\", \"r\"))\n",
+    "input_path = cfg.get(\"input_path\")\n",
+    "output_path = cfg.get(\"output_path\").replace(\"{compression}\", f\"{compression}\")\n",
+    "table = cfg.get(\"table\")\n",
+    "volume = cfg.get(\"volume\")\n",
+    "write_mode = cfg.get(\"write_mode\")\n",
+    "\n",
+    "pprint.pprint(cfg, indent=4)\n",
+    "print(output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "38587e58-efc0-43ad-8515-cc01224292c1",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dbx.pixels import Catalog\n",
+    "from dbx.pixels.dicom import DicomMetaExtractor # The Dicom transformers\n",
+    "catalog = Catalog(\n",
+    "    spark,\n",
+    "    table=table,\n",
+    "    volume=volume)\n",
+    "catalog_df = catalog.catalog(path=output_path)\n",
+    "meta_df = DicomMetaExtractor(catalog, deep=False).transform(catalog_df)\n",
+    "catalog.save(meta_df, mode=write_mode)\n",
+    "display(spark.table(table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "37afa4ee-9ba9-42fd-8249-eea8f2cbdcf4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from dbx.pixels import Catalog\n",
+    "from dbx.pixels.dicom import DicomMetaExtractor # The Dicom transformers\n",
+    "catalog = Catalog(\n",
+    "    spark,\n",
+    "    table=table,\n",
+    "    volume=volume)\n",
+    "catalog_df = catalog.catalog(path=output_path)\n",
+    "meta_df = DicomMetaExtractor(catalog, deep=True).transform(catalog_df)\n",
+    "catalog.save(meta_df, mode=write_mode)\n",
+    "display(spark.table(table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "e131427f-763a-4d83-8a87-b0e16e4ae6ef",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": {
+    "hardware": {
+     "accelerator": null,
+     "gpuPoolId": null,
+     "memory": null
+    }
+   },
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "3"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "jpeg2000 v3 - index",
+   "widgets": {}
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Fixes #149 
- put file hash under the `if deep:` test
- put key deletion under `if deep:` test

From ~2 minutes before failing
To 20 seconds putting `if deep:` around file hash computation
To 10-11 seconds with dicom_utils change (putting `if deep` around key deletion)