### PR TITLE
Add OpenSlide data downloader notebook

### DIFF
--- a/notebooks/data-downloaders/Openslide Sample Data downloader Notebook.ipynb
+++ b/notebooks/data-downloaders/Openslide Sample Data downloader Notebook.ipynb
@@ -1,6 +1,29 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "3a75cbac-af5e-471b-8b17-9b979ab99dcb",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "\n",
+    "# Notebook Overview\n",
+    "\n",
+    "This notebook demonstrates how to download, verify, and manage DICOM test data from the OpenSlide project. It includes steps to fetch metadata, download files with integrity checks, and inspect the downloaded dataset. The workflow is designed for use in Databricks environments, following workspace policies for responsible resource usage and data management.\n",
+    "\n",
+    "## Requirements\n",
+    "- Serverless Notebook Compute\n",
+    "- Assumes catalog, schema, volume `hls_radiology.openslide-cs-cmu-edu.test-data` UC volume\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 0,
    "metadata": {


### PR DESCRIPTION
Pre-cursor for fixing #160 
OpenSlide has test DICOMs for Pathology. The downloader notebook will follow the posted .yaml file and download the files listed into a volume. Mostly for internal use at Databricks. Also useful for customers in downloading data to build their own test data archive.