### PR TITLE
Reverted cookie skip

### DIFF
--- a/apps/dicom-web/app.py
+++ b/apps/dicom-web/app.py
@@ -69,7 +69,7 @@ _SKIP_PROXY_HEADERS = frozenset(
         "host",
         "content-length",
         "transfer-encoding",
-        "cookie",
+        #"cookie",
         "x-forwarded-access-token",
         "x-forwarded-user",
         "x-forwarded-email",


### PR DESCRIPTION
Cookie is mandatory to correctly share the pixels_table between the apps and other preferences.