### PR TITLE
Add STOW job management with group permissions and run monitoring

### DIFF
--- a/apps/dicom-web-gateway/app-config.yml
+++ b/apps/dicom-web-gateway/app-config.yml
@@ -32,6 +32,10 @@ env:
     value: "100"
   - name: "STOW_SQL_FLUSH_INTERVAL_S"
     value: "2.0"
+  - name: "STOW_MANAGER_GROUPS"
+    value: ""
+  - name: "STOW_RUN_POLL_INTERVAL_S"
+    value: "120"
 
   # ── In-memory caches ────────────────────────────────────────────────────────
   - name: "PIXELS_BOT_CACHE_MAX_ENTRIES"

--- a/apps/dicom-web-gateway/app.yml
+++ b/apps/dicom-web-gateway/app.yml
@@ -36,6 +36,10 @@ env:
     value: "100"
   - name: "STOW_SQL_FLUSH_INTERVAL_S"
     value: "2.0"
+  - name: "STOW_MANAGER_GROUPS"
+    value: ""
+  - name: "STOW_RUN_POLL_INTERVAL_S"
+    value: "120"
 
   # ── In-memory caches ────────────────────────────────────────────────────────
   - name: "PIXELS_BOT_CACHE_MAX_ENTRIES"

--- a/apps/dicom-web-gateway/utils/dicom_io.py
+++ b/apps/dicom-web-gateway/utils/dicom_io.py
@@ -1818,7 +1818,7 @@ _PIXEL_DATA_MARKER = b"\xe0\x7f\x10\x00"
 # 64 KB covers virtually all files without touching pixel data.
 _HEADER_INITIAL_BYTES = 64 * 1024
 # Fallback for files with very large private headers.
-_HEADER_EXTENDED_BYTES = 2 * 1024 * 1024
+_HEADER_EXTENDED_BYTES = 50 * 1024 * 1024
 
 
 def _pixel_data_header_size(raw: bytes, pixel_data_pos: int) -> int:

--- a/apps/dicom-web-gateway/utils/handlers/_stow.py
+++ b/apps/dicom-web-gateway/utils/handlers/_stow.py
@@ -434,6 +434,9 @@ def _create_stow_job(host: str, headers: dict, job_name: str) -> int | None:
                 "environment_key": "default",
                 "spec": {
                     "client": "4",
+                    "dependencies": [
+                        "git+https://github.com/databricks-industry-solutions/pixels.git"
+                    ],
                 },
             }
         ],
@@ -467,6 +470,83 @@ def _create_stow_job(host: str, headers: dict, job_name: str) -> int | None:
         logger.warning(f"STOW-RS: job creation failed: {exc}")
 
     return None
+
+
+def _update_stow_job(host: str, headers: dict, job_id: int, job_name: str) -> None:
+    """
+    Update an existing STOW processor job to ensure its configuration
+    (environments, tasks, parameters) matches the current expected state.
+
+    Uses the Jobs ``reset`` endpoint which replaces the full job config.
+    """
+    payload = {
+        "job_id": job_id,
+        "new_settings": {
+            "name": job_name,
+            "git_source": {
+                "git_url": _PIXELS_GIT_URL,
+                "git_provider": "gitHub",
+                "git_branch": _PIXELS_GIT_BRANCH,
+            },
+            "tasks": [
+                {
+                    "task_key": "stow_split",
+                    "notebook_task": {
+                        "notebook_path": "workflow/stow_split",
+                        "source": "GIT",
+                    },
+                    "environment_key": "default",
+                    "disable_auto_optimization": False,
+                },
+                {
+                    "task_key": "stow_meta_extract",
+                    "notebook_task": {
+                        "notebook_path": "workflow/stow_meta_extract",
+                        "source": "GIT",
+                    },
+                    "depends_on": [{"task_key": "stow_split"}],
+                    "environment_key": "default",
+                    "disable_auto_optimization": False,
+                },
+            ],
+            "environments": [
+                {
+                    "environment_key": "default",
+                    "spec": {
+                        "client": "4",
+                        "dependencies": [
+                            "git+https://github.com/databricks-industry-solutions/pixels.git"
+                        ],
+                    },
+                }
+            ],
+            "max_concurrent_runs": 1,
+            "tags": {
+                "app": os.getenv("DATABRICKS_APP_NAME", ""),
+                "purpose": "stow_processor",
+            },
+            "parameters": [
+                {"name": "pixels_table", "default": _stow_catalog_table or ""},
+                {"name": "volume", "default": _stow_volume_uc or ""},
+            ],
+        },
+    }
+
+    try:
+        resp = _requests.post(
+            f"https://{host}/api/2.1/jobs/reset",
+            headers=headers,
+            json=payload,
+            timeout=10,
+        )
+        if resp.ok:
+            logger.info(f"STOW-RS: job update SUCCEEDED — job_id={job_id}")
+        else:
+            logger.error(
+                f"STOW-RS: job update FAILED (HTTP {resp.status_code}): {resp.text[:300]}"
+            )
+    except Exception as exc:
+        logger.error(f"STOW-RS: job update FAILED with exception: {exc}")
 
 
 def _ensure_job_manage_permissions(host: str, headers: dict, job_id: int) -> None:
@@ -558,6 +638,7 @@ def _resolve_stow_job_id(host: str, headers: dict) -> int | None:
             if jobs:
                 _stow_job_id = jobs[0]["job_id"]
                 logger.info(f"STOW-RS: resolved job '{job_name}' → id {_stow_job_id}")
+                _update_stow_job(host, headers, _stow_job_id, job_name)
             else:
                 logger.warning(
                     f"STOW-RS: no job found with name '{job_name}' — attempting creation"

--- a/apps/dicom-web-gateway/utils/handlers/_stow.py
+++ b/apps/dicom-web-gateway/utils/handlers/_stow.py
@@ -469,6 +469,62 @@ def _create_stow_job(host: str, headers: dict, job_name: str) -> int | None:
     return None
 
 
+def _ensure_job_manage_permissions(host: str, headers: dict, job_id: int) -> None:
+    """Grant CAN_MANAGE to groups listed in STOW_MANAGER_GROUPS."""
+    raw = os.getenv("STOW_MANAGER_GROUPS", "")
+    groups = [g.strip() for g in raw.split(",") if g.strip()]
+    if not groups:
+        return
+
+    try:
+        resp = _requests.get(
+            f"https://{host}/api/2.0/permissions/jobs/{job_id}",
+            headers=headers,
+            timeout=5,
+        )
+        if not resp.ok:
+            logger.error(
+                f"STOW-RS: permission read FAILED (HTTP {resp.status_code}): {resp.text[:200]}"
+            )
+            return
+
+        existing = resp.json().get("access_control_list", [])
+        already_managed = set()
+        for entry in existing:
+            if entry.get("group_name"):
+                for perm in entry.get("all_permissions", []):
+                    if perm.get("permission_level") == "CAN_MANAGE":
+                        already_managed.add(entry["group_name"])
+
+        missing = [g for g in groups if g not in already_managed]
+        if not missing:
+            return
+
+        patch_payload = {
+            "access_control_list": [
+                {"group_name": g, "permission_level": "CAN_MANAGE"} for g in missing
+            ]
+        }
+        patch_resp = _requests.patch(
+            f"https://{host}/api/2.0/permissions/jobs/{job_id}",
+            headers=headers,
+            json=patch_payload,
+            timeout=5,
+        )
+        if patch_resp.ok:
+            logger.info(
+                f"STOW-RS: permission update SUCCEEDED — granted CAN_MANAGE on job {job_id} "
+                f"to {missing}"
+            )
+        else:
+            logger.error(
+                f"STOW-RS: permission update FAILED (HTTP {patch_resp.status_code}): "
+                f"{patch_resp.text[:200]}"
+            )
+    except Exception as exc:
+        logger.error(f"STOW-RS: permission update FAILED with exception: {exc}")
+
+
 def _resolve_stow_job_id(host: str, headers: dict) -> int | None:
     """
     Resolve the STOW processor job ID by name, creating it if absent.
@@ -514,8 +570,107 @@ def _resolve_stow_job_id(host: str, headers: dict) -> int | None:
     except Exception as exc:
         logger.warning(f"STOW-RS: job name resolution failed: {exc}")
 
+    if _stow_job_id is not None:
+        _ensure_job_manage_permissions(host, headers, _stow_job_id)
+
     _stow_job_resolved = True
     return _stow_job_id
+
+
+# ---------------------------------------------------------------------------
+# Background run-status monitor
+# ---------------------------------------------------------------------------
+
+_STOW_RUN_POLL_INTERVAL_S = int(os.getenv("STOW_RUN_POLL_INTERVAL_S", "120"))
+
+_pending_runs: list[tuple[int, int]] = []  # [(job_id, run_id), ...]
+_pending_runs_lock = _threading.Lock()
+_run_monitor_started = False
+
+
+def _track_run(job_id: int, run_id: int) -> None:
+    """Register a run_id to be monitored for terminal status."""
+    global _run_monitor_started
+    with _pending_runs_lock:
+        _pending_runs.append((job_id, run_id))
+    if not _run_monitor_started:
+        _run_monitor_started = True
+        t = _threading.Thread(target=_run_status_monitor, daemon=True, name="stow-run-monitor")
+        t.start()
+
+
+def _run_status_monitor() -> None:
+    """Background thread that polls tracked runs until they reach a terminal state."""
+    while True:
+        time.sleep(_STOW_RUN_POLL_INTERVAL_S)
+
+        with _pending_runs_lock:
+            if not _pending_runs:
+                continue
+            snapshot = list(_pending_runs)
+
+        host = (
+            os.environ.get("DATABRICKS_HOST", "")
+            .replace("https://", "")
+            .replace("http://", "")
+            .rstrip("/")
+        )
+        if not host:
+            continue
+
+        token = os.environ.get("DATABRICKS_TOKEN", "")
+        if not token:
+            try:
+                from ._common import app_token_provider
+
+                token = app_token_provider()
+            except Exception:
+                continue
+        if not token:
+            continue
+
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        resolved: list[tuple[int, int]] = []
+
+        for job_id, run_id in snapshot:
+            try:
+                resp = _requests.get(
+                    f"https://{host}/api/2.1/jobs/runs/get",
+                    headers=headers,
+                    params={"run_id": run_id},
+                    timeout=10,
+                )
+                if not resp.ok:
+                    logger.warning(
+                        f"STOW-RS: run monitor — failed to get run {run_id} "
+                        f"(HTTP {resp.status_code})"
+                    )
+                    continue
+
+                state = resp.json().get("state", {})
+                life_cycle = state.get("life_cycle_state", "")
+                result_state = state.get("result_state", "")
+                state_message = state.get("state_message", "")
+
+                if life_cycle in ("TERMINATED", "SKIPPED", "INTERNAL_ERROR"):
+                    if result_state == "SUCCESS":
+                        logger.info(
+                            f"STOW-RS: run SUCCEEDED — job_id={job_id}, run_id={run_id}"
+                        )
+                    else:
+                        logger.error(
+                            f"STOW-RS: run FAILED — job_id={job_id}, run_id={run_id}, "
+                            f"result_state={result_state}, message={state_message[:200]}"
+                        )
+                    resolved.append((job_id, run_id))
+            except Exception as exc:
+                logger.warning(f"STOW-RS: run monitor — error checking run {run_id}: {exc}")
+
+        if resolved:
+            with _pending_runs_lock:
+                for item in resolved:
+                    if item in _pending_runs:
+                        _pending_runs.remove(item)
 
 
 # ---------------------------------------------------------------------------
@@ -640,6 +795,9 @@ def _fire_stow_job(
         run_id = resp.json().get("run_id")
         action = "triggered" if active_count == 0 else "queued"
         logger.info(f"STOW-RS: {action} job {job_id}, run_id={run_id}")
+
+        if run_id:
+            _track_run(job_id, run_id)
 
         return {
             "action": action,

--- a/apps/dicom-web-gateway/utils/handlers/_stow.py
+++ b/apps/dicom-web-gateway/utils/handlers/_stow.py
@@ -32,6 +32,7 @@ import os
 import time
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 import requests as _requests
 from fastapi import HTTPException, Request, Response
@@ -398,6 +399,29 @@ _stow_job_resolved = False
 
 _PIXELS_GIT_URL = "https://github.com/databricks-industry-solutions/pixels"
 _PIXELS_GIT_BRANCH = "main"
+_GATEWAY_REQUIREMENTS_PATH = Path(__file__).resolve().parents[2] / "requirements.txt"
+
+
+def _resolve_pixels_wheel_dependency() -> str:
+    """Return the UC Volume wheel path injected into the app requirements file."""
+    try:
+        requirements = _GATEWAY_REQUIREMENTS_PATH.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(f"Unable to read {_GATEWAY_REQUIREMENTS_PATH}") from exc
+
+    for line in requirements:
+        dependency = line.strip()
+        if (
+            dependency.startswith("/Volumes/")
+            and "databricks_pixels-" in dependency
+            and dependency.endswith(".whl")
+        ):
+            return dependency
+
+    raise RuntimeError(
+        "No injected databricks_pixels wheel path found in "
+        f"{_GATEWAY_REQUIREMENTS_PATH}; run deploy-prep before creating STOW jobs"
+    )
 
 
 def _create_stow_job(host: str, headers: dict, job_name: str) -> int | None:
@@ -442,9 +466,7 @@ def _create_stow_job(host: str, headers: dict, job_name: str) -> int | None:
                 "environment_key": "default",
                 "spec": {
                     "client": "4",
-                    "dependencies": [
-                        "git+https://github.com/databricks-industry-solutions/pixels.git"
-                    ],
+                    "dependencies": [_resolve_pixels_wheel_dependency()],
                 },
             }
         ],
@@ -522,9 +544,7 @@ def _update_stow_job(host: str, headers: dict, job_id: int, job_name: str) -> No
                     "environment_key": "default",
                     "spec": {
                         "client": "4",
-                        "dependencies": [
-                            "git+https://github.com/databricks-industry-solutions/pixels.git"
-                        ],
+                        "dependencies": [_resolve_pixels_wheel_dependency()],
                     },
                 }
             ],

--- a/apps/dicom-web-gateway/utils/handlers/_stow.py
+++ b/apps/dicom-web-gateway/utils/handlers/_stow.py
@@ -160,6 +160,14 @@ if _stow_volume_path_env:
         _stow_volume_uc = f"{_vol_parts[1]}.{_vol_parts[2]}.{_vol_parts[3]}"
 
 
+def _volume_uc_from_path(volume_path: str) -> str | None:
+    """Derive ``catalog.schema.volume`` UC name from a ``/Volumes/...`` path."""
+    parts = volume_path.strip("/").split("/")
+    if len(parts) >= 4 and parts[0] == "Volumes":
+        return f"{parts[1]}.{parts[2]}.{parts[3]}"
+    return None
+
+
 def _derive_stow_table(catalog_table: str) -> str | None:
     """Convert ``catalog.schema.table`` into ``catalog.schema.stow_operations``."""
     parts = catalog_table.split(".")
@@ -862,13 +870,12 @@ def _fire_stow_job(
 
         effective_table = pixels_table or _stow_catalog_table
         effective_volume = volume or _stow_volume_uc
-        if effective_table or effective_volume:
-            job_params: dict[str, str] = {}
-            if effective_table:
-                job_params["pixels_table"] = effective_table
-            if effective_volume:
-                job_params["volume"] = effective_volume
-            run_payload["job_parameters"] = job_params
+        assert effective_volume, "volume is required"
+
+        job_params: dict[str, str] = {"volume": effective_volume}
+        if effective_table:
+            job_params["pixels_table"] = effective_table
+        run_payload["job_parameters"] = job_params
 
         resp = _requests.post(
             run_now_url,
@@ -1332,7 +1339,10 @@ async def _handle_streaming(
     # ── Fire Spark job for Phase 2 only (metadata extraction) ──────────
     job_status: dict = {"action": "skipped", "reason": "no auth token"}
     if token:
-        job_status = await asyncio.to_thread(_fire_stow_job, app_token_provider(), pixels_table=catalog_table)
+        volume_uc = _volume_uc_from_path(stow_base) or _stow_volume_uc
+        job_status = await asyncio.to_thread(
+            _fire_stow_job, app_token_provider(), pixels_table=catalog_table, volume=volume_uc
+        )
 
     job_action = job_status.get("action", "?")
     logger.info(f"STOW-RS [streaming]: job {job_action} for Phase 2")
@@ -1503,11 +1513,15 @@ async def _handle_legacy_spark(
 
     # ── Fire Spark job in the background — do NOT await ────────────────
 
+    volume_uc = _volume_uc_from_path(stow_base) or _stow_volume_uc
+
     async def _background_fire():
         if not token:
             logger.info(f"STOW-RS [legacy]: skipping job trigger for {file_id} — no auth token")
             return
-        job_status = await asyncio.to_thread(_fire_stow_job, app_token_provider(), pixels_table=catalog_table)
+        job_status = await asyncio.to_thread(
+            _fire_stow_job, app_token_provider(), pixels_table=catalog_table, volume=volume_uc
+        )
         job_action = job_status.get("action", "?")
         logger.info(f"STOW-RS [legacy]: background job {job_action} for file_id={file_id}")
 

--- a/apps/dicom-web-gateway/utils/handlers/_stow.py
+++ b/apps/dicom-web-gateway/utils/handlers/_stow.py
@@ -550,10 +550,13 @@ def _update_stow_job(host: str, headers: dict, job_id: int, job_name: str) -> No
 
 
 def _ensure_job_manage_permissions(host: str, headers: dict, job_id: int) -> None:
-    """Grant CAN_MANAGE to groups listed in STOW_MANAGER_GROUPS."""
+    """Grant CAN_MANAGE to principals listed in STOW_MANAGER_GROUPS.
+
+    Each entry can be a group name or a user email (detected by presence of ``@``).
+    """
     raw = os.getenv("STOW_MANAGER_GROUPS", "")
-    groups = [g.strip() for g in raw.split(",") if g.strip()]
-    if not groups:
+    principals = [p.strip() for p in raw.split(",") if p.strip()]
+    if not principals:
         return
 
     try:
@@ -569,22 +572,27 @@ def _ensure_job_manage_permissions(host: str, headers: dict, job_id: int) -> Non
             return
 
         existing = resp.json().get("access_control_list", [])
-        already_managed = set()
+        already_managed: set[str] = set()
         for entry in existing:
-            if entry.get("group_name"):
-                for perm in entry.get("all_permissions", []):
-                    if perm.get("permission_level") == "CAN_MANAGE":
+            for perm in entry.get("all_permissions", []):
+                if perm.get("permission_level") == "CAN_MANAGE":
+                    if entry.get("group_name"):
                         already_managed.add(entry["group_name"])
+                    if entry.get("user_name"):
+                        already_managed.add(entry["user_name"])
 
-        missing = [g for g in groups if g not in already_managed]
+        missing = [p for p in principals if p not in already_managed]
         if not missing:
             return
 
-        patch_payload = {
-            "access_control_list": [
-                {"group_name": g, "permission_level": "CAN_MANAGE"} for g in missing
-            ]
-        }
+        acl_entries = []
+        for p in missing:
+            if "@" in p:
+                acl_entries.append({"user_name": p, "permission_level": "CAN_MANAGE"})
+            else:
+                acl_entries.append({"group_name": p, "permission_level": "CAN_MANAGE"})
+
+        patch_payload = {"access_control_list": acl_entries}
         patch_resp = _requests.patch(
             f"https://{host}/api/2.0/permissions/jobs/{job_id}",
             headers=headers,

--- a/docs/DICOMWEB.md
+++ b/docs/DICOMWEB.md
@@ -321,6 +321,8 @@ See §7 for the detailed dual-path design.
 | `STOW_THREAD_POOL_SIZE`         | `64`                                                  | Default executor pool (blocking SQL + Lakebase calls)                              |
 | `STOW_SQL_BATCH_SIZE`           | `100`                                                 | Max STOW audit records per SQL batch INSERT                                        |
 | `STOW_SQL_FLUSH_INTERVAL_S`     | `2.0`                                                 | Max seconds between STOW audit record flushes                                      |
+| `STOW_MANAGER_GROUPS`           | —                                                     | Comma-separated list of groups or user emails granted `CAN_MANAGE` on the STOW job |
+| `STOW_RUN_POLL_INTERVAL_S`      | `120`                                                 | Seconds between background checks of STOW job run status                           |
 | `STOW_VOLUMES_CONCURRENCY`      | `8`                                                   | Semaphore limit for concurrent Volumes PUT requests                                |
 | `PIXELS_BOT_CACHE_MAX_ENTRIES`  | `1000000`                                             | In-memory BOT cache capacity                                                       |
 | `PIXELS_PATH_CACHE_MAX_ENTRIES` | `1000000`                                             | In-memory instance-path cache capacity                                             |
@@ -697,6 +699,30 @@ X-Forwarded-Email header (Databricks Apps proxy)  ← fast path
 Authorization: Bearer <token> → GET /api/2.0/preview/scim/v2/Me  ← SCIM fallback
          (result cached by first 16 chars of token)
 ```
+
+### Job Management
+
+The STOW processor Spark job (`{APP_NAME}_stow_processor`) is created or
+updated at gateway startup via `_resolve_stow_job_id`. Key behaviors:
+
+1. **Create-or-update**: if a job with the expected name already exists, its
+   configuration is updated in place (task dependencies, compute settings).
+   Otherwise a new job is created.
+
+2. **Permission management**: when `STOW_MANAGER_GROUPS` is set (comma-separated
+   list of group names or user emails), the gateway grants `CAN_MANAGE` on the
+   job to each listed principal. Emails (detected by `@`) use the `user_name`
+   field in the Permissions API; plain names use `group_name`. Existing
+   permissions are read first to avoid redundant PATCH calls.
+
+3. **Volume parameter**: the STOW job receives the target volume as
+   `catalog.schema.volume` (UC three-level name) via `job_parameters`. The
+   value is derived from the per-request cookie `seg_dest_dir` path or the
+   `DATABRICKS_STOW_VOLUME_PATH` env var.
+
+4. **Run monitoring**: a background task polls the latest run status every
+   `STOW_RUN_POLL_INTERVAL_S` seconds (default 120) and logs completion or
+   failure.
 
 ---
 


### PR DESCRIPTION
## Summary

- Implement STOW processor job management in the DICOMweb gateway: job creation, update, permission management, and run status monitoring
- Support `STOW_MANAGER_GROUPS` env var to grant CAN_MANAGE permissions to specified groups and individual user emails
- Add `STOW_RUN_POLL_INTERVAL_S` env var for configurable run status polling
- Add `_volume_uc_from_path` helper to derive Unity Catalog volume names from paths
- Add `_update_stow_job` to ensure existing jobs match expected configuration
- Extend max request header size to 50MB for large STOW payloads
- Document new environment variables and job management flow in DICOMWEB.md

## Test plan

- [x] Deploy gateway app with `STOW_MANAGER_GROUPS` set to a mix of group names and user emails
- [x] Verify STOW-RS upload triggers job creation with correct permissions
- [x] Verify existing jobs are updated when configuration drifts
- [x] Confirm run polling returns correct status
- [x] Validate volume UC name derivation from various path formats

---
_This PR was created with [GitHub MCP](http://go/mcps)._