### PR TITLE
Add in-memory metadata extraction instead of extract files to disk first

### DIFF
--- a/src/dbx/pixels/catalog.py
+++ b/src/dbx/pixels/catalog.py
@@ -4,7 +4,12 @@ from pyspark.sql import DataFrame, functions as f
 from pyspark.sql.streaming.query import StreamingQuery
 
 from dbx.pixels.logging import LoggerProvider
-from dbx.pixels.utils import DEFAULT_UNZIP_WORKERS, identify_type_udf, unzip_map_func
+from dbx.pixels.utils import (
+    DEFAULT_UNZIP_WORKERS,
+    identify_type_udf,
+    unzip_inmemory_map_func,
+    unzip_map_func,
+)
 
 # dfZipWithIndex helper function
 
@@ -128,14 +133,16 @@ class Catalog:
     def __repr__(self):
         return f'Catalog(spark, table="{self._table}")'
 
-    def __reader(self, path: str, pattern: str = "*", recurse: bool = True):
-        return (
+    def __reader(self, path: str, pattern: str = "*", recurse: bool = True, keepContent: bool = False):
+        df = (
             self._spark.read.format("binaryFile")
             .option("pathGlobFilter", pattern)
             .option("recursiveFileLookup", str(recurse).lower())
             .load(path)
-            .drop("content")
         )
+        if not keepContent:
+            df = df.drop("content")
+        return df
 
     def __streamReader(
         self,
@@ -147,6 +154,7 @@ class Catalog:
         includeExistingFiles: bool = True,
         allowOverwrites: bool = False,
         maxFileAge: str = None,
+        keepContent: bool = False,
     ):
         reader = (
             self._spark.readStream.format("cloudFiles")
@@ -164,7 +172,10 @@ class Catalog:
         if useManagedFileEvents:
             reader = reader.option("cloudFiles.useManagedFileEvents", "true")
 
-        return reader.load(path).drop("content")
+        df = reader.load(path)
+        if not keepContent:
+            df = df.drop("content")
+        return df
 
     def catalog(
         self,
@@ -261,67 +272,42 @@ class Catalog:
                 includeExistingFiles,
                 allowOverwrites,
                 maxFileAge,
+                keepContent=extractZip,
             ).withColumn("original_path", f.col("path"))
 
             if extractZip:
-                logger.info("Started unzip process")
+                logger.info("Started in-memory unzip process")
 
                 if zipRepartition is not None:
                     df = df.repartition(zipRepartition)
 
-                unzip_stream = (
-                    df.mapInPandas(
-                        unzip_map_func("path", extractZipBasePath),
-                        schema=df.schema,
-                    )
-                    .writeStream.format("delta")
-                    .outputMode("append")
-                    .option(
-                        "checkpointLocation", f"{self.streamCheckpointBasePath}/{self._table}_unzip"
-                    )
-                    .option("maxRecordsPerFile", maxUnzippedRecordsPerFile)
-                    .option("mergeSchema", "true")
-                    .trigger(
-                        availableNow=self._triggerAvailableNow,
-                        processingTime=self._triggerProcessingTime,
-                    )
-                    .queryName(self._queryName + "_unzip")
-                    .toTable(f"{self._table}_unzip")
+                # In-memory zip extraction: explode zip entries into rows
+                # without writing extracted files to disk
+                df = df.mapInPandas(
+                    unzip_inmemory_map_func("path", "content"),
+                    schema=df.schema,
                 )
 
-                if self._triggerAvailableNow:
-                    unzip_stream.awaitTermination()
-
-                logger.info("Unzip process completed")
-
-                df = self._spark.readStream.option("maxFilesPerTrigger", "1").table(
-                    f"{self._table}_unzip"
-                )
-
-                # Rebalance the extracted files among workers
-                df = df.repartition(int(maxUnzippedRecordsPerFile // maxZipElementsPerPartition))
+                logger.info("In-memory unzip process configured")
 
         else:
-            df = self.__reader(path, pattern, recurse).withColumn("original_path", f.col("path"))
+            df = self.__reader(path, pattern, recurse, keepContent=extractZip).withColumn(
+                "original_path", f.col("path")
+            )
             if extractZip:
-                logger.info("Started unzip process")
+                logger.info("Started in-memory unzip process")
 
                 if zipRepartition is not None:
                     df = df.repartition(zipRepartition)
 
-                df.mapInPandas(
-                    unzip_map_func("path", extractZipBasePath, max_workers=maxUnzipWorkers),
+                # In-memory zip extraction: explode zip entries into rows
+                # without writing extracted files to disk
+                df = df.mapInPandas(
+                    unzip_inmemory_map_func("path", "content"),
                     schema=df.schema,
-                ).write.format("delta").mode("append").saveAsTable(f"{self._table}_unzip")
-
-                logger.info("Unzip process completed")
-
-                df = self._spark.read.table(f"{self._table}_unzip")
-
-                records = df.count()
-                df = df.repartition(
-                    int(records // maxZipElementsPerPartition) | maxZipElementsPerPartition
                 )
+
+                logger.info("In-memory unzip process completed")
 
         # Generate paths
         df = Catalog._with_path_meta(df)

--- a/src/dbx/pixels/catalog.py
+++ b/src/dbx/pixels/catalog.py
@@ -186,7 +186,9 @@ class Catalog:
         streamCheckpointBasePath: str = None,
         triggerProcessingTime: str = None,
         triggerAvailableNow: bool = None,
-        extractZip: bool = False,
+        skipZip: bool = False,
+        extractZipToDisk: bool = False,
+        extractZipInMemory: bool = False,
         extractZipBasePath: str = None,
         maxFilesPerTrigger: int = 50000,
         maxUnzippedRecordsPerFile: int = 102400,
@@ -210,8 +212,15 @@ class Catalog:
         - streamCheckpointBasePath (str, optional): The path for saving streaming progress. Defaults to volume location + "/checkpoints/".
         - triggerProcessingTime (str, optional): The processing time interval for streaming triggers, e.g., '5 seconds', '1 minute'.
         - triggerAvailableNow (bool, optional): If True, processes all available data in multiple batches then terminates the query.
-        - extractZip (bool, optional): Whether to extract zip files found in the path. Defaults to False.
-        - extractZipBasePath (str, optional): The base path for extracted zip files. Defaults to volume location + "/unzipped/".
+        - skipZip (bool, optional): Explicitly skip zip files; they are listed as-is but not extracted.
+          When no flag is set, skip is the default behavior.
+        - extractZipToDisk (bool, optional): Extract zip files to disk (at extractZipBasePath), then process
+          extracted files via a Spark job. Defaults to False.
+        - extractZipInMemory (bool, optional): Extract zip files in memory during the Spark job; extracted
+          content is available in the 'content' column. Defaults to False.
+        Note: skipZip, extractZipToDisk, and extractZipInMemory are mutually exclusive; only one may be True.
+        - extractZipBasePath (str, optional): The base path for extracted zip files (used only with
+          extractZipToDisk=True). Defaults to volume location + "/unzipped/".
         - maxFilesPerTrigger (int, optional): The maximum number of files to process per trigger in streaming. Defaults to 1000.
         - maxUnzippedRecordsPerFile (int, optional): The maximum number of records per file when unzipping. Defaults to 102400.
         - maxZipElementsPerPartition (int, optional): The maximum number of zip elements per partition. Defaults to 32.
@@ -225,7 +234,8 @@ class Catalog:
           Defaults to False.
         - maxFileAge (str, optional): Maximum age of files considered for ingestion by Auto Loader (for example: "90 days").
           Defaults to None (Auto Loader default).
-        - maxUnzipWorkers (int, optional): The maximum number of workers for parallel unzip. Defaults to 16.
+        - maxUnzipWorkers (int, optional): The maximum number of workers for parallel unzip (used only with
+          extractZipToDisk=True). Defaults to 16.
 
         Returns:
         DataFrame: A DataFrame of the cataloged data, with metadata and optionally extracted contents from zip files.
@@ -233,6 +243,15 @@ class Catalog:
 
         assert self._spark is not None
         assert self._spark.version is not None
+
+        _zip_flag_count = sum([skipZip, extractZipToDisk, extractZipInMemory])
+        if _zip_flag_count > 1:
+            raise ValueError(
+                "Only one of skipZip, extractZipToDisk, extractZipInMemory can be True at a time. "
+                "These options are mutually exclusive."
+            )
+        if _zip_flag_count == 0:
+            skipZip = True
 
         self._anon = self._is_anon(path)
 
@@ -272,17 +291,56 @@ class Catalog:
                 includeExistingFiles,
                 allowOverwrites,
                 maxFileAge,
-                keepContent=extractZip,
+                keepContent=extractZipInMemory,
             ).withColumn("original_path", f.col("path"))
 
-            if extractZip:
+            if extractZipToDisk:
+                logger.info("Started disk unzip process")
+
+                if zipRepartition is not None:
+                    df = df.repartition(zipRepartition)
+
+                unzip_stream = (
+                    df.mapInPandas(
+                        unzip_map_func("path", extractZipBasePath),
+                        schema=df.schema,
+                    )
+                    .writeStream.format("delta")
+                    .outputMode("append")
+                    .option(
+                        "checkpointLocation",
+                        f"{self.streamCheckpointBasePath}/{self._table}_unzip",
+                    )
+                    .option("maxRecordsPerFile", maxUnzippedRecordsPerFile)
+                    .option("mergeSchema", "true")
+                    .trigger(
+                        availableNow=self._triggerAvailableNow,
+                        processingTime=self._triggerProcessingTime,
+                    )
+                    .queryName(self._queryName + "_unzip")
+                    .toTable(f"{self._table}_unzip")
+                )
+
+                if self._triggerAvailableNow:
+                    unzip_stream.awaitTermination()
+
+                logger.info("Disk unzip process completed")
+
+                df = self._spark.readStream.option("maxFilesPerTrigger", "1").table(
+                    f"{self._table}_unzip"
+                )
+
+                # Rebalance the extracted files among workers
+                df = df.repartition(
+                    int(maxUnzippedRecordsPerFile // maxZipElementsPerPartition)
+                )
+
+            elif extractZipInMemory:
                 logger.info("Started in-memory unzip process")
 
                 if zipRepartition is not None:
                     df = df.repartition(zipRepartition)
 
-                # In-memory zip extraction: explode zip entries into rows
-                # without writing extracted files to disk
                 df = df.mapInPandas(
                     unzip_inmemory_map_func("path", "content"),
                     schema=df.schema,
@@ -291,17 +349,36 @@ class Catalog:
                 logger.info("In-memory unzip process configured")
 
         else:
-            df = self.__reader(path, pattern, recurse, keepContent=extractZip).withColumn(
-                "original_path", f.col("path")
-            )
-            if extractZip:
+            df = self.__reader(
+                path, pattern, recurse, keepContent=extractZipInMemory
+            ).withColumn("original_path", f.col("path"))
+
+            if extractZipToDisk:
+                logger.info("Started disk unzip process")
+
+                if zipRepartition is not None:
+                    df = df.repartition(zipRepartition)
+
+                df.mapInPandas(
+                    unzip_map_func("path", extractZipBasePath, max_workers=maxUnzipWorkers),
+                    schema=df.schema,
+                ).write.format("delta").mode("append").saveAsTable(f"{self._table}_unzip")
+
+                logger.info("Disk unzip process completed")
+
+                df = self._spark.read.table(f"{self._table}_unzip")
+
+                records = df.count()
+                df = df.repartition(
+                    int(records // maxZipElementsPerPartition) | maxZipElementsPerPartition
+                )
+
+            elif extractZipInMemory:
                 logger.info("Started in-memory unzip process")
 
                 if zipRepartition is not None:
                     df = df.repartition(zipRepartition)
 
-                # In-memory zip extraction: explode zip entries into rows
-                # without writing extracted files to disk
                 df = df.mapInPandas(
                     unzip_inmemory_map_func("path", "content"),
                     schema=df.schema,

--- a/src/dbx/pixels/dicom/dicom_meta_extractor.py
+++ b/src/dbx/pixels/dicom/dicom_meta_extractor.py
@@ -16,6 +16,10 @@ class DicomMetaExtractor(Transformer):
 
     Uses mapInPandas with a ThreadPoolExecutor to concurrently read DICOM file
     headers over the network, maximizing I/O throughput on each Spark task.
+
+    When a 'content' column is present in the input DataFrame (e.g. from
+    in-memory zip extraction), the extractor reads DICOM data directly from
+    the binary content instead of opening the file from the path.
     """
 
     MAX_WORKERS = 32
@@ -24,6 +28,7 @@ class DicomMetaExtractor(Transformer):
         self,
         catalog,
         inputCol="local_path",
+        contentCol="content",
         outputCol="meta",
         basePath="dbfs:/",
         deep=False,
@@ -33,6 +38,7 @@ class DicomMetaExtractor(Transformer):
         permissive=False,
     ):
         self.inputCol = inputCol
+        self.contentCol = contentCol
         self.outputCol = outputCol
         self.basePath = basePath
         self.catalog = catalog
@@ -60,6 +66,10 @@ class DicomMetaExtractor(Transformer):
         Perform Dicom to metadata transformation using mapInPandas with
         concurrent I/O via ThreadPoolExecutor.
 
+        When a 'content' column is present (from in-memory zip extraction),
+        DICOM data is read directly from the binary content without file I/O.
+        Otherwise, files are read from paths via cloud_open().
+
         Input:
           col('extension')
           col('is_anon')
@@ -70,10 +80,14 @@ class DicomMetaExtractor(Transformer):
         df = df.withColumn("is_anon", lit(self.catalog.is_anon()))
 
         input_col = self.inputCol
+        content_col = self.contentCol
         output_col = self.outputCol
         deep = self.deep
         max_workers = self.maxWorkers
         remove_un_tags = self.remove_un_tags
+
+        # Detect whether in-memory content is available
+        has_content = content_col in [field.name for field in df.schema.fields]
 
         # Build output schema: all existing columns + the new meta column (as StringType initially)
         out_schema = t.StructType(
@@ -82,15 +96,30 @@ class DicomMetaExtractor(Transformer):
 
         def _extract_meta(iterator: Iterator[pd.DataFrame]) -> Iterator[pd.DataFrame]:
             """mapInPandas function that uses a thread pool for concurrent DICOM I/O."""
+            import io
+
             import simplejson as json
             from pydicom import dcmread
 
-            def _process_file(path: str, deep: bool, anon: bool, remove_un_tags: bool) -> str:
+            def _process_file(
+                path: str, content: bytes, deep: bool, anon: bool, remove_un_tags: bool
+            ) -> str:
                 try:
-                    fp, fsize = cloud_open(path, anon)
+                    if content is not None and len(content) > 0:
+                        # Read from in-memory content (from zip extraction)
+                        fp = io.BytesIO(
+                            bytes(content) if not isinstance(content, bytes) else content
+                        )
+                        fsize = len(content)
+                    else:
+                        # Fall back to reading from path
+                        fp, fsize = cloud_open(path, anon)
+
                     with dcmread(fp, defer_size=1000, stop_before_pixels=(not deep)) as dataset:
                         meta_js = extract_metadata(dataset, deep, remove_un_tags=remove_un_tags)
                         if deep:
+                            if hasattr(fp, "seek"):
+                                fp.seek(0)
                             meta_js["hash"] = hashlib.sha1(fp.read()).hexdigest()
                         meta_js["file_size"] = fsize
                         return json.dumps(meta_js, ignore_nan=True)
@@ -108,12 +137,17 @@ class DicomMetaExtractor(Transformer):
             for pdf in iterator:
                 paths = pdf[input_col].tolist()
                 anon_flags = pdf["is_anon"].tolist()
+                contents = (
+                    pdf[content_col].tolist() if has_content and content_col in pdf.columns else [None] * len(paths)
+                )
 
                 with ThreadPoolExecutor(max_workers=max_workers) as executor:
                     meta_results = list(
                         executor.map(
-                            lambda args: _process_file(args[0], deep, args[1], remove_un_tags),
-                            zip(paths, anon_flags),
+                            lambda args: _process_file(
+                                args[0], args[1], deep, args[2], remove_un_tags
+                            ),
+                            zip(paths, contents, anon_flags),
                         )
                     )
 

--- a/src/dbx/pixels/utils.py
+++ b/src/dbx/pixels/utils.py
@@ -164,6 +164,80 @@ def unzip_map_func(path_col="path", volume_base_path="", max_workers=DEFAULT_UNZ
     return _unzip_map
 
 
+def unzip_inmemory_map_func(path_col="path", content_col="content", max_workers=DEFAULT_UNZIP_WORKERS):
+    """Factory returning a mapInPandas-compatible iterator for in-memory zip extraction.
+
+    Instead of extracting zip files to disk, this reads zip contents into memory
+    and yields one row per file inside the zip with the binary content included.
+    Non-zip files are passed through unchanged.
+
+    The output DataFrame has the same schema as the input (which must include a
+    binary 'content' column from binaryFile format). For zip entries:
+    - `path` is set to a synthetic path: <original_zip_path>::<entry_name>
+    - `content` carries the raw bytes of the entry
+    - `length` is updated to the entry's uncompressed size
+    - `modificationTime` is preserved from the original zip file row
+
+    Args:
+        path_col: Name of the column containing file paths.
+        content_col: Name of the binary content column.
+        max_workers: Maximum number of concurrent threads for reading zip entries.
+
+    Usage:
+        df.mapInPandas(
+            unzip_inmemory_map_func("path", "content"),
+            schema=df.schema,
+        )
+    """
+
+    def _unzip_inmemory_map(iterator: Iterator[pd.DataFrame]) -> Iterator[pd.DataFrame]:
+        for pdf in iterator:
+            rows = []
+            for _, row in pdf.iterrows():
+                path = row[path_col]
+                content = row[content_col]
+
+                # Check if this file is a zip archive
+                if content is not None and len(content) > 0:
+                    content_bytes = bytes(content) if not isinstance(content, bytes) else content
+                    bio = BytesIO(content_bytes)
+                    if zipfile.is_zipfile(bio):
+                        bio.seek(0)
+                        with zipfile.ZipFile(bio, "r") as zf:
+                            for entry_name in zf.namelist():
+                                # Skip directories and hidden files
+                                if entry_name.endswith("/") or os.path.basename(
+                                    entry_name
+                                ).startswith("."):
+                                    continue
+                                try:
+                                    entry_data = zf.read(entry_name)
+                                    new_row = row.copy()
+                                    new_row[path_col] = f"{path}::{entry_name}"
+                                    new_row[content_col] = entry_data
+                                    if "length" in new_row.index:
+                                        new_row["length"] = len(entry_data)
+                                    rows.append(new_row)
+                                except Exception as e:
+                                    logger.warning(
+                                        f"Failed to read zip entry {entry_name} from {path}: {e}"
+                                    )
+                    else:
+                        # Not a zip file, pass through as-is
+                        rows.append(row)
+                else:
+                    # No content (shouldn't happen with binaryFile), pass through
+                    rows.append(row)
+
+            if rows:
+                yield pd.DataFrame(rows)
+            else:
+                # Yield empty DataFrame with same columns to maintain schema
+                yield pdf.iloc[0:0]
+
+    return _unzip_inmemory_map
+
+
 # ── PySpark UDFs are created lazily (only when accessed) ─────────────
 def __getattr__(name):
     if name == "identify_type_udf":

--- a/tests/dbx/test_zip.py
+++ b/tests/dbx/test_zip.py
@@ -1,3 +1,4 @@
+import pytest
 from pyspark.sql import SparkSession
 
 from conftest import (
@@ -10,29 +11,130 @@ from conftest import (
 from dbx.pixels import Catalog
 
 
-def test_catalog_unzip(spark: SparkSession):
-    """Test in-memory zip extraction (no disk extraction)."""
+# ── Batch mode tests ─────────────────────────────────────────────────
+
+
+def test_zip_skip_default(spark: SparkSession):
+    """skipZip=True (default): zip files appear as single rows, not extracted."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    catalog_df = catalog.catalog(path=ZIP_FILE_PATH)
+
+    assert catalog_df is not None
+    # Should see the zip files themselves, not their contents
+    assert catalog_df.count() > 0
+    # content column is dropped by default
+    assert "content" not in catalog_df.columns
+
+
+def test_zip_disk_extraction(spark: SparkSession):
+    """extractZipToDisk=True: extracts zip files to disk, processes extracted files."""
     catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
     catalog_df = catalog.catalog(
-        path=ZIP_FILE_PATH, extractZip=True
+        path=ZIP_FILE_PATH,
+        extractZipToDisk=True,
+        extractZipBasePath=UNZIP_BASE_PATH,
     )
 
     assert catalog_df is not None
-    # content column should be present when extractZip=True (in-memory mode)
+    # content column should NOT be present in disk mode (files are on disk)
+    assert "content" not in catalog_df.columns
+
+    catalog.save(df=catalog_df)
+    assert catalog.load().count() == 30
+
+
+def test_zip_memory_extraction(spark: SparkSession):
+    """extractZipInMemory=True: extracts zip files in memory, content column present."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    catalog_df = catalog.catalog(
+        path=ZIP_FILE_PATH,
+        extractZipInMemory=True,
+    )
+
+    assert catalog_df is not None
+    # content column should be present in memory mode
     assert "content" in catalog_df.columns
 
     # Drop content before saving to avoid persisting large binary blobs
     catalog.save(df=catalog_df.drop("content"))
-
     assert catalog.load().count() == 30
 
 
-def test_catalog_unzip_stream(spark: SparkSession):
-    """Test in-memory zip extraction in streaming mode."""
+def test_zip_mutually_exclusive_disk_and_memory(spark: SparkSession):
+    """Setting extractZipToDisk and extractZipInMemory together should raise ValueError."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        catalog.catalog(
+            path=ZIP_FILE_PATH,
+            extractZipToDisk=True,
+            extractZipInMemory=True,
+        )
+
+
+def test_zip_mutually_exclusive_skip_and_disk(spark: SparkSession):
+    """Setting skipZip and extractZipToDisk together should raise ValueError."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        catalog.catalog(
+            path=ZIP_FILE_PATH,
+            skipZip=True,
+            extractZipToDisk=True,
+        )
+
+
+def test_zip_mutually_exclusive_all_three(spark: SparkSession):
+    """Setting all three zip flags should raise ValueError."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        catalog.catalog(
+            path=ZIP_FILE_PATH,
+            skipZip=True,
+            extractZipToDisk=True,
+            extractZipInMemory=True,
+        )
+
+
+# ── Streaming mode tests ─────────────────────────────────────────────
+
+
+def test_zip_skip_streaming(spark: SparkSession):
+    """skipZip=True in streaming: zip files appear as single rows."""
     catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
     catalog_df = catalog.catalog(
         path=ZIP_FILE_PATH,
-        extractZip=True,
+        streaming=True,
+        streamCheckpointBasePath=CHECKPOINT_BASE_PATH,
+    )
+
+    assert catalog_df is not None
+    assert catalog_df.isStreaming
+    # content column is dropped by default
+    assert "content" not in [field.name for field in catalog_df.schema.fields]
+
+
+def test_zip_disk_streaming(spark: SparkSession):
+    """extractZipToDisk=True in streaming: extracts to disk, processes files."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    catalog_df = catalog.catalog(
+        path=ZIP_FILE_PATH,
+        extractZipToDisk=True,
+        extractZipBasePath=UNZIP_BASE_PATH,
+        streaming=True,
+        streamCheckpointBasePath=CHECKPOINT_BASE_PATH,
+    )
+
+    assert catalog_df is not None
+
+    catalog.save(df=catalog_df)
+    assert catalog.load().count() == 30
+
+
+def test_zip_memory_streaming(spark: SparkSession):
+    """extractZipInMemory=True in streaming: extracts in memory, content column present."""
+    catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
+    catalog_df = catalog.catalog(
+        path=ZIP_FILE_PATH,
+        extractZipInMemory=True,
         streaming=True,
         streamCheckpointBasePath=CHECKPOINT_BASE_PATH,
     )
@@ -41,5 +143,4 @@ def test_catalog_unzip_stream(spark: SparkSession):
 
     # Drop content before saving to avoid persisting large binary blobs
     catalog.save(df=catalog_df.drop("content"))
-
     assert catalog.load().count() == 30

--- a/tests/dbx/test_zip.py
+++ b/tests/dbx/test_zip.py
@@ -11,30 +11,35 @@ from dbx.pixels import Catalog
 
 
 def test_catalog_unzip(spark: SparkSession):
+    """Test in-memory zip extraction (no disk extraction)."""
     catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
     catalog_df = catalog.catalog(
-        path=ZIP_FILE_PATH, extractZip=True, extractZipBasePath=UNZIP_BASE_PATH
+        path=ZIP_FILE_PATH, extractZip=True
     )
 
     assert catalog_df is not None
+    # content column should be present when extractZip=True (in-memory mode)
+    assert "content" in catalog_df.columns
 
-    catalog.save(df=catalog_df)
+    # Drop content before saving to avoid persisting large binary blobs
+    catalog.save(df=catalog_df.drop("content"))
 
     assert catalog.load().count() == 30
 
 
 def test_catalog_unzip_stream(spark: SparkSession):
+    """Test in-memory zip extraction in streaming mode."""
     catalog = Catalog(spark, table=TABLE, volume=VOLUME_UC)
     catalog_df = catalog.catalog(
         path=ZIP_FILE_PATH,
         extractZip=True,
-        extractZipBasePath=UNZIP_BASE_PATH,
         streaming=True,
         streamCheckpointBasePath=CHECKPOINT_BASE_PATH,
     )
 
     assert catalog_df is not None
 
-    catalog.save(df=catalog_df)
+    # Drop content before saving to avoid persisting large binary blobs
+    catalog.save(df=catalog_df.drop("content"))
 
     assert catalog.load().count() == 30


### PR DESCRIPTION
*************** benchmark test results ********************

Benchmark: In-Memory vs Disk Zip Extraction (100 zips × 5 DICOM = 500 files)

Serverless compute, 128×128 px 16-bit synthetic DICOM, ~144 KB per zip.

Phase                                 In-Memory             Disk-First
Catalog + extraction        0.83 s                      354.21 s
Metadata extraction        41.92 s                     31.71 s
End-to-end                      42.75 s                     385.92 s
In-memory is 9.0× faster end-to-end. The extraction phase is 427× faster (0.83 s vs 354.21 s) — eliminating all UC Volume I/O, the intermediate _unzip Delta table, and subprocess unzip calls. The metadata phase is slightly slower in-memory (42 s vs 32 s) because DICOM bytes flow through Spark partitions rather than being read from local disk, but this is dwarfed by the extraction savings.

The speedup advantage grows with dataset size: at 10 zips (50 files) the gap was 1.1×; at 100 zips (500 files) it widens to 9.0× as the disk I/O and Delta table overhead dominate the disk-first path. Normal company data size is well above the 100 zip files, so the savings will be much bigger.

